### PR TITLE
config/add_unittest_gh_action

### DIFF
--- a/.github/workflows/python-unittest.yml
+++ b/.github/workflows/python-unittest.yml
@@ -11,12 +11,7 @@ on:
 
 jobs:
   test:
-    name: Unit tests
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # Test on the following Python versions.
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
     env:
       # Disable venv use for simpler testing.
       USE_VENV: false
@@ -24,13 +19,11 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.8
       - name: Install dependencies
-        run: |
-          $GITHUB_WORKSPACE/launch.sh
+        run: $GITHUB_WORKSPACE/launch.sh
       - name: Test with unittest
-        run: |
-          python -m unittest -v $GITHUB_WORKSPACE/tests/*.py 
+        run: python -m unittest -v $GITHUB_WORKSPACE/tests/*.py 

--- a/.github/workflows/python-unittest.yml
+++ b/.github/workflows/python-unittest.yml
@@ -26,4 +26,5 @@ jobs:
       - name: Install dependencies
         run: $GITHUB_WORKSPACE/launch.sh
       - name: Test with unittest
-        run: python -m unittest -v $GITHUB_WORKSPACE/tests/*.py 
+        run: |
+          python -m unittest -v $GITHUB_WORKSPACE/tests/*.py >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/python-unittest.yml
+++ b/.github/workflows/python-unittest.yml
@@ -1,0 +1,36 @@
+name: Python Unit Test
+
+# Run when PRs are made into main and after commits to main.
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Test on the following Python versions.
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    env:
+      # Disable venv use for simpler testing.
+      USE_VENV: false
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          $GITHUB_WORKSPACE/launch.sh
+      - name: Test with unittest
+        run: |
+          python -m unittest -v $GITHUB_WORKSPACE/tests/*.py 

--- a/.github/workflows/python-unittest.yml
+++ b/.github/workflows/python-unittest.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # Test on the following Python versions.
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     env:
       # Disable venv use for simpler testing.
       USE_VENV: false

--- a/.github/workflows/python-unittest.yml
+++ b/.github/workflows/python-unittest.yml
@@ -1,6 +1,6 @@
 name: Python Unit Test
 
-# Run when PRs are made into main and after commits to main.
+# Run when PRs are made to merge into main and after commits to main.
 on:
   pull_request:
     branches:
@@ -27,4 +27,6 @@ jobs:
         run: $GITHUB_WORKSPACE/launch.sh
       - name: Test with unittest
         run: |
-          python -m unittest -v $GITHUB_WORKSPACE/tests/*.py >> $GITHUB_STEP_SUMMARY
+          # Store output in GITHUB_STEP_SUMMARY for easy reading on Github.com
+          python -m unittest -v $GITHUB_WORKSPACE/tests/*.py &> $GITHUB_STEP_SUMMARY
+          cat $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Currently configured to run the python unit tests for each commit to `main` and for PRs that will merge into `main`. 

In a PR if any test fails, we will see the following:
![Screenshot 2023-09-18 at 12 55 14 PM](https://github.com/ProjectUnifree/unifree/assets/13296512/bb2c4dda-93c7-4fb7-8bc3-3f2043ec896d)

And if we go to the job page, we see the `python unittest` output:
![Screenshot 2023-09-18 at 12 55 26 PM](https://github.com/ProjectUnifree/unifree/assets/13296512/e271d2f1-21c5-49c6-820f-455d22b83428)
