### PR TITLE
Add ChatGPT warning to README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Migrate Unity projects to other engines!
 
-:warning: This is an early prototype. :warning:
+:warning: This is an early prototype. :warning:  
+
+### ChatGPT
+:warning: Using ChatGPT may lead to leaking sensitive info :warning:
+
+If you are interested how ChatGPT can lead to leaking sensitive info:   
+[Exploring the risks and alternatives of ChatGPT](https://www.ibm.com/blog/exploring-the-risks-and-alternatives-of-chatgpt-paving-a-path-to-trustworthy-ai/)
+
 
 ### Features
 


### PR DESCRIPTION
Discussed in discord. A warning to be used while ChatGPT can still be used. There is a discussion in discord about using local model to translate files.