### PR TITLE
Added support for multi-process local LLM

### DIFF
--- a/tests/test_csharp_migration_strategies.py
+++ b/tests/test_csharp_migration_strategies.py
@@ -17,7 +17,7 @@ class CSharpCompilationUnitMigrationWithLLMProxy(CSharpCompilationUnitMigrationW
         pass
 
     def load_llm(self) -> unifree.LLM:
-        return TrivialLLM()
+        return TrivialLLM(self.config)
 
 
 class TestCSharpCompilationUnitMigrationWithLLM(unittest.TestCase):
@@ -25,6 +25,9 @@ class TestCSharpCompilationUnitMigrationWithLLM(unittest.TestCase):
         strategy = CSharpCompilationUnitMigrationWithLLMProxy(unifree.FileMigrationSpec('', '', ''), to_default_dict({
             "prompts": {
                 "test": "This is a ${CODE}"
+            },
+            "llm": {
+                "class": "TrivialLLM"
             }
         }))
 
@@ -34,6 +37,9 @@ class TestCSharpCompilationUnitMigrationWithLLM(unittest.TestCase):
         strategy = CSharpCompilationUnitMigrationWithLLMProxy(unifree.FileMigrationSpec('', '', ''), to_default_dict({
             "prompts": {
                 "test": "This is a ${TEST} with ${MACRO}"
+            },
+            "llm": {
+                "class": "TrivialLLM"
             }
         }))
 
@@ -44,7 +50,11 @@ class TestCSharpCompilationUnitMigrationWithLLM(unittest.TestCase):
         strategy = CSharpCompilationUnitMigrationWithLLMProxy(unifree.FileMigrationSpec('', '', ''), to_default_dict({
             "prompts": {
                 "test": "This is a ${TEST} with ${MACRO}"
+            },
+            "llm": {
+                "class": "TrivialLLM"
             }
+
         }))
 
         try:
@@ -239,6 +249,9 @@ class CSharpCompilationUnitToSingleFileWithLLMProxy(CSharpCompilationUnitToSingl
             def count_tokens(self, source_text: str) -> int:
                 return len(source_text)
 
+            def initialize(self) -> None:
+                pass
+
         local_llm = LocalLLM()
         local_llm._parent = self
 
@@ -313,6 +326,9 @@ def _setup_test_config(target) -> None:
             "full": "full",
             "class_only": "class_only",
             "methods_only": "methods_only",
+        },
+        "llm": {
+            "class": "TrivialLLM"
         }
     })
 

--- a/tests/test_multiprocess_local_llm.py
+++ b/tests/test_multiprocess_local_llm.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) AppLovin. and its affiliates. All rights reserved.
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+
+from unifree.llms import MultiprocessLocalLLM
+
+
+class TestMultiprocessLocalLLM(unittest.TestCase):
+
+    def test_translate(self):
+        config = {
+            "class": "MultiprocessLocalLLM",
+            "llm_config": {
+                "class": "TrivialLLM",
+                "config": {
+                    "key": "value"
+                }
+            },
+
+            "wrapper_config": {
+                "num_workers": 5,
+                "query_timeout_sec": 1,
+            }
+        }
+
+        mp_llm = MultiprocessLocalLLM(config)
+        mp_llm.initialize()
+
+        count = mp_llm.count_tokens("some text")
+        self.assertEqual(9, count)
+
+        self.assertTrue(mp_llm.fits_in_one_prompt(123))
+
+        def map_func(query_ix_loc):
+            nonlocal mp_llm
+            return query_ix_loc, mp_llm.query(f"QUERY {query_ix_loc}")
+
+        inputs = range(200)
+        with ThreadPoolExecutor(max_workers=4) as e:
+            results = e.map(map_func, inputs)
+
+        results_count = 0
+        for query_ix, response in results:
+            self.assertEqual(f"QUERY {query_ix}", response)
+            results_count += 1
+
+        self.assertEqual(200, results_count)

--- a/unifree/__init__.py
+++ b/unifree/__init__.py
@@ -61,6 +61,12 @@ class LLM(ABC):
         """
         raise NotImplementedError
 
+    def initialize(self) -> None:
+        """
+        Initialize the LLM
+        """
+        raise NotImplementedError
+
     def fits_in_one_prompt(self, token_count: int) -> bool:
         """
         Check if the given token count fits into one prompt

--- a/unifree/csharp_migration_strategies.py
+++ b/unifree/csharp_migration_strategies.py
@@ -9,7 +9,7 @@ import tree_sitter
 from unifree import log, MigrationStrategy, FileMigrationSpec, utils, LLM
 from unifree.llms.code_extrators import extract_first_source_code, extract_header_implementation
 from unifree.source_code_parsers import CSharpCodeParser
-from unifree.utils import load_class
+from unifree.utils import load_class, load_llm
 
 
 class CSharpCompilationUnitMigrationStrategy(MigrationStrategy, ABC):
@@ -148,7 +148,11 @@ class CSharpCompilationUnitMigrationWithLLM(CSharpCompilationUnitMigrationStrate
     def __init__(self, file_migration_spec: FileMigrationSpec, config: Dict) -> None:
         super().__init__(file_migration_spec, config)
 
-        self._llm = self.load_llm()
+        if "llm" not in config:
+            raise RuntimeError(f"No 'llm' key found in the tool configuration")
+
+        self._llm = load_llm(config["llm"])
+        self._llm.initialize()
 
     @property
     def llm(self) -> LLM:
@@ -174,10 +178,6 @@ class CSharpCompilationUnitMigrationWithLLM(CSharpCompilationUnitMigrationStrate
             text = text.replace('${' + key + '}', value)
 
         return text
-
-    def load_llm(self) -> LLM:
-        llm_class = load_class(self.config["llm"]["class"], "llms")
-        return llm_class(self.config)
 
 
 class CSharpCompilationUnitToSingleFileWithLLM(CSharpCompilationUnitMigrationWithLLM):

--- a/unifree/csharp_migration_strategies.py
+++ b/unifree/csharp_migration_strategies.py
@@ -151,7 +151,7 @@ class CSharpCompilationUnitMigrationWithLLM(CSharpCompilationUnitMigrationStrate
         if "llm" not in config:
             raise RuntimeError(f"No 'llm' key found in the tool configuration")
 
-        self._llm = load_llm(config["llm"])
+        self._llm = self.load_llm()
         self._llm.initialize()
 
     @property
@@ -178,6 +178,16 @@ class CSharpCompilationUnitMigrationWithLLM(CSharpCompilationUnitMigrationStrate
             text = text.replace('${' + key + '}', value)
 
         return text
+
+    def load_llm(self) -> LLM:
+        """
+        Load target LLM.
+
+        Please note: this method is separate for unit tests to be able to override it
+
+        :return: Newly loaded LLM
+        """
+        return load_llm(self.config["llm"])
 
 
 class CSharpCompilationUnitToSingleFileWithLLM(CSharpCompilationUnitMigrationWithLLM):

--- a/unifree/free.py
+++ b/unifree/free.py
@@ -4,6 +4,7 @@ import argparse
 import os.path
 import platform
 import sys
+from typing import Optional
 
 import unifree
 from unifree import utils, log
@@ -11,9 +12,9 @@ from unifree import utils, log
 
 def run_migration(
         config: str,
-        open_ai_key: str,
         source: str,
         destination: str,
+        llm_secret_key: Optional[str] = None,
         verbose: bool = False,
 ):
     if verbose:
@@ -21,8 +22,11 @@ def run_migration(
 
     try:
         config = utils.load_config(config)
-        config["openai_key"] = open_ai_key
         config["verbose"] = verbose
+
+        if llm_secret_key and "llm" in config and "config" in config["llm"]:
+            config["llm"]["config"]["secret_key"] = llm_secret_key
+
     except Exception as e:
         log.error(f"Unable to start: {config} is invalid: {e}", exc_info=e)
         return -1
@@ -78,12 +82,6 @@ def migrate():
         help=f"Name of the migration configuration. Must match file name in the ./configs folder",
     )
     args_parser.add_argument(
-        '--open_ai_key', '-k',
-        required=True,
-        type=str,
-        help=f"OpenAI API secret key. Obtain your key from 'https://platform.openai.com/account/api-keys'",
-    )
-    args_parser.add_argument(
         '--source', '-s',
         required=True,
         type=str,
@@ -94,6 +92,12 @@ def migrate():
         required=True,
         type=str,
         help=f"Path to the destination project folder. Migrated files would be stored there",
+    )
+    args_parser.add_argument(
+        '--llm_secret_key', '-k',
+        required=False,
+        type=str,
+        help=f"Secret key for the current LLM (optional)",
     )
     args_parser.add_argument(
         '--verbose', '-v',

--- a/unifree/llms/__init__.py
+++ b/unifree/llms/__init__.py
@@ -3,3 +3,4 @@
 
 from .chatgpt_llm import ChatGptLLM
 from .trivial_llm import TrivialLLM
+from .multiprocess_local_llm import MultiprocessLocalLLM

--- a/unifree/llms/chatgpt_llm.py
+++ b/unifree/llms/chatgpt_llm.py
@@ -12,17 +12,18 @@ class ChatGptLLM(LLM):
     """
     This class adds a capability to query chat GPT for a completion
     """
-    _llm_config: Dict
     _config: Dict
 
     def __init__(self, config: Dict) -> None:
         super().__init__()
 
-        self._config = config
-        self._llm_config = config["llm"]["config"]
+        self._config = config["config"]
+
+    def initialize(self) -> None:
+        pass
 
     def query(self, user: str, system: Optional[str] = None, history: Optional[List[QueryHistoryItem]] = None) -> str:
-        openai.api_key = self._config['openai_key']
+        openai.api_key = self._config['secret_key']
 
         if log.is_debug():
             short_user_query = user[:50].replace("\n", " ")
@@ -51,7 +52,7 @@ class ChatGptLLM(LLM):
             })
 
             completion = openai.ChatCompletion.create(
-                model=self._llm_config["model"],
+                model=self._config["model"],
                 messages=messages
             )
 
@@ -67,10 +68,10 @@ class ChatGptLLM(LLM):
             raise RuntimeError(f"ChatGPT query failed: {e}")
 
     def fits_in_one_prompt(self, token_count: int) -> bool:
-        return token_count < self._llm_config["max_tokens"]
+        return token_count < self._config["max_tokens"]
 
     def count_tokens(self, source_text: str) -> int:
-        encoding = tiktoken.encoding_for_model(self._llm_config["model"])
+        encoding = tiktoken.encoding_for_model(self._config["model"])
         num_tokens = len(encoding.encode(source_text))
 
         return num_tokens

--- a/unifree/llms/chatgpt_llm.py
+++ b/unifree/llms/chatgpt_llm.py
@@ -10,7 +10,19 @@ from unifree import LLM, log, QueryHistoryItem
 
 class ChatGptLLM(LLM):
     """
-    This class adds a capability to query chat GPT for a completion
+    This class adds a capability to query chat GPT for a completion.
+
+    The configuration looks like:
+
+    ```
+    llm:
+      class: ChatGptLLM
+      config:
+          secret_key: <INSERTED DYNAMICALLY BY free.py>
+          model: gpt-4
+          max_tokens: 4000
+    ```
+
     """
     _config: Dict
 

--- a/unifree/llms/multiprocess_local_llm.py
+++ b/unifree/llms/multiprocess_local_llm.py
@@ -9,6 +9,23 @@ from unifree.utils import load_llm
 
 
 class MultiprocessLocalLLM(LLM):
+    """
+    This class wraps an LLM implementation and run inference (aka 'query' method) in separate processes on the local box.
+
+    The configuration would look like:
+
+    ```
+    llm:
+      class: MultiprocessLocalLLM
+      llm_config:
+          class: <wrapped LLM class>
+          config <wrapped LLM config>
+
+        wrapper_config
+          num_workers: 5,
+          query_timeout_sec: 10
+    ```
+    """
     _shared_executor: Optional[ProcessPoolExecutor] = None
     _query_timeout_sec: int = 20
 

--- a/unifree/llms/multiprocess_local_llm.py
+++ b/unifree/llms/multiprocess_local_llm.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# Copyright (c) AppLovin. and its affiliates. All rights reserved.
+from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass
+from typing import Optional, List, Dict
+
+from unifree import LLM, QueryHistoryItem, log
+from unifree.utils import load_llm
+
+
+class MultiprocessLocalLLM(LLM):
+    _shared_executor: Optional[ProcessPoolExecutor] = None
+    _query_timeout_sec: int = 20
+
+    _config: Dict
+    _local_uninitialized_model: Optional[LLM]
+
+    def __init__(self, config: Dict) -> None:
+        super().__init__()
+
+        self._config = config
+
+    def initialize(self) -> None:
+        llm_config = self._config["llm_config"]
+        self._local_uninitialized_model = load_llm(llm_config)
+
+    def query(self, user: str, system: Optional[str] = None, history: Optional[List[QueryHistoryItem]] = None) -> str:
+        self.maybe_initialize_shared_executor(self._config)
+
+        result_future = self._shared_executor.submit(_multi_process_worker_translate, _QueryRequest(
+            user=user,
+            system=system,
+            history=history
+        ))
+        try:
+            result = result_future.result(timeout=self._query_timeout_sec)
+            if result.is_success():
+                return result.response
+            else:
+                raise RuntimeError(f"LocalLLM query failed: {result.exception}")
+        except Exception as e:
+            raise RuntimeError(f"LocalLLM query failed: {e}")
+
+    def fits_in_one_prompt(self, token_count: int) -> bool:
+        assert self._local_uninitialized_model is not None
+        return self._local_uninitialized_model.fits_in_one_prompt(token_count)
+
+    def count_tokens(self, source_text: str) -> int:
+        assert self._local_uninitialized_model is not None
+        return self._local_uninitialized_model.count_tokens(source_text)
+
+    @classmethod
+    def maybe_initialize_shared_executor(cls, config: Dict):
+        if not cls._shared_executor:
+            wrapper_config = config["wrapper_config"]
+            llm_config = config["llm_config"]
+            cls._shared_executor = ProcessPoolExecutor(
+                max_workers=wrapper_config["num_workers"],
+                initializer=_multi_process_worker_init,
+                initargs=(llm_config,)
+            )
+            cls._query_timeout_sec = wrapper_config["query_timeout_sec"]
+
+
+@dataclass
+class _QueryRequest:
+    """
+    This class represents a request ot make a query to the LLM.
+    """
+    user: str
+    system: Optional[str] = None
+    history: Optional[List[QueryHistoryItem]] = None
+
+
+@dataclass
+class _QueryResult:
+    """
+    This object represents response to a given query
+    """
+    response: str
+    exception: Optional[Exception] = None
+
+    def is_success(self) -> bool:
+        return self.exception is None
+
+
+_process_local_llm: Optional[LLM] = None
+
+
+def _multi_process_worker_init(config: Dict):
+    global _process_local_llm
+
+    try:
+        _process_local_llm = load_llm(config)
+        _process_local_llm.initialize()
+    except Exception as e:
+        log.error(f"Failed to load local LLM model with: {e}", exc_info=e)
+        _process_local_llm = None
+
+
+def _multi_process_worker_translate(query: _QueryRequest) -> _QueryResult:
+    global _process_local_llm
+
+    try:
+        return _QueryResult(
+            response=_process_local_llm.query(
+                user=query.user,
+                system=query.system,
+                history=query.history,
+            )
+        )
+    except Exception as e:
+        log.error(f"Failed to query local LLM: {e}", exc_info=e)
+        return _QueryResult(
+            response='',
+            exception=e
+        )

--- a/unifree/llms/trivial_llm.py
+++ b/unifree/llms/trivial_llm.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) AppLovin. and its affiliates. All rights reserved.
-from typing import Optional, List
+from typing import Optional, List, Dict
 
 from unifree import LLM, QueryHistoryItem
 
@@ -10,6 +10,9 @@ class TrivialLLM(LLM):
     This is a trivial implementation of an LLM used for unit tests and an example for other implementations
     """
 
+    def __init__(self, config: Dict) -> None:
+        super().__init__()
+
     def query(self, user: str, system: Optional[str] = None, history: Optional[List[QueryHistoryItem]] = None) -> str:
         return user
 
@@ -18,3 +21,6 @@ class TrivialLLM(LLM):
 
     def count_tokens(self, source_text: str) -> int:
         return len(source_text)
+
+    def initialize(self) -> None:
+        pass

--- a/unifree/llms/trivial_llm.py
+++ b/unifree/llms/trivial_llm.py
@@ -7,7 +7,15 @@ from unifree import LLM, QueryHistoryItem
 
 class TrivialLLM(LLM):
     """
-    This is a trivial implementation of an LLM used for unit tests and an example for other implementations
+    This is a trivial implementation of an LLM used for unit tests and an example for other implementations.
+
+    The configuration looks like:
+
+    ```
+    llm:
+      class: TrivialLLM
+      config:
+    ```
     """
 
     def __init__(self, config: Dict) -> None:

--- a/unifree/project_migration_strategies.py
+++ b/unifree/project_migration_strategies.py
@@ -2,10 +2,9 @@
 # Copyright (c) AppLovin. and its affiliates. All rights reserved.
 import os.path
 from abc import ABC
-from multiprocessing import cpu_count
 from typing import List, Union, Dict, Optional, Iterable
 
-from tqdm.contrib.concurrent import process_map
+from tqdm.contrib.concurrent import thread_map
 
 from unifree import log, MigrationStrategy, utils, FileMigrationSpec
 
@@ -16,11 +15,7 @@ class ConcurrentMigrationStrategy(MigrationStrategy, ABC):
         super().__init__(config)
 
     def map_concurrently(self, fn, iterables, **tqdm_kwargs) -> Iterable:
-        # Run verbose mode jobs in a single thread
-        if self.config["verbose"]:
-            return map(fn, iterables)
-        else:
-            return process_map(fn, iterables, **tqdm_kwargs)
+        return thread_map(fn, iterables, **tqdm_kwargs)
 
 
 class CreateMigrations(ConcurrentMigrationStrategy):
@@ -66,7 +61,6 @@ class CreateMigrations(ConcurrentMigrationStrategy):
         log.info(f"Computing migration strategies for {len(project_files):,} files...")
         results = self.map_concurrently(
             self._map_file_path_to_migration, project_files,
-            max_workers=int(cpu_count() // 2),
             unit='path',
             chunksize=1,
         )
@@ -156,7 +150,6 @@ class ExecuteMigrations(ConcurrentMigrationStrategy):
 
         results = self.map_concurrently(
             self._execute_strategy, self._strategies,
-            max_workers=cpu_count(),
             unit='file',
             chunksize=1,
         )

--- a/unifree/utils.py
+++ b/unifree/utils.py
@@ -8,6 +8,8 @@ from typing import Type, Dict, Any
 
 import yaml
 
+from unifree import LLM
+
 
 def load_config(config_name: str) -> Dict[str, Any]:
     from unifree import log
@@ -45,6 +47,11 @@ def load_class(class_name: str, module: str) -> Type:
         raise RuntimeError(f"Class {class_name} not found")
 
     return loaded_class
+
+
+def load_llm(config: Dict) -> LLM:
+    llm_class = load_class(config["class"], "llms")
+    return llm_class(config)
 
 
 def camel_to_snake(camel_case_str: str) -> str:


### PR DESCRIPTION
Add `TestMultiprocessLocalLLM `, a class that can wrap an LLM implementation and run inference (aka `query` method) in separate processes on the local box.

The configuration would look like:
```
llm:
  class: MultiprocessLocalLLM
  llm_config:
      class: <wrapped LLM class>
      config <wrapped LLM config>

    wrapper_config
      num_workers: 5,
      query_timeout_sec: 10