### PR TITLE
Use RAG LLM Trick to Support Known Translations

### DIFF
--- a/configs/godot.yaml
+++ b/configs/godot.yaml
@@ -49,6 +49,21 @@ target:
   lower_folder_names: true
   extension: .gd
 
+known_translations:
+  target_engine: godot
+  embedding_function: krlvi/sentence-t5-base-nlpl-code_search_net
+  result_count: 5
+  user_request: |
+    Remember this correct translation from Unity: 
+    ```
+    ${SOURCE}
+    ```
+    is translated as:
+    ```
+    ${TARGET}
+    ```
+  assistant_response: Certainly! I will remember this translation.
+
 strategies:
   .cs: CSharpCompilationUnitToSingleFileWithLLM
 

--- a/known_translations/godot.yaml
+++ b/known_translations/godot.yaml
@@ -1,0 +1,72 @@
+translations:
+  - title: Ternary Operators
+    source: |
+      variable = {condition} ? (true_statement) : (false_statement);
+    target: |
+      variable = {translated_true_statement} if {translated_condition} else "{translated_false_statement}
+  # ---------------------------------------------------------------------------------------------------------------------
+  - title: Start() Function
+    source: |
+      private void Start()
+      {
+        {function_body}
+      }
+
+    target: |
+      func _ready() -> void:
+      {
+        {translated_function_body}
+      }
+  # ---------------------------------------------------------------------------------------------------------------------
+  - title: OnEnable() Function
+    source: |
+      private void OnEnable()
+      {
+        {function_body}
+      }
+
+    target: |
+      func _enter_tree() -> void:
+      {
+        {translated_function_body}
+      }
+  # ---------------------------------------------------------------------------------------------------------------------
+  - title: OnDisable() Function
+    source: |
+      private void OnDisable()
+      {
+        {function_body}
+      }
+
+    target: |
+      func _exit_tree() -> void:
+      {
+        {translated_function_body}
+      }
+  # ---------------------------------------------------------------------------------------------------------------------
+  - title: FixedUpdate() Function
+    source: |
+      private void FixedUpdate()
+      {
+        {function_body}
+      }
+
+    target: |
+      func _physics_process(delta: float) -> void:
+      {
+        {translated_function_body}
+      }
+  # ---------------------------------------------------------------------------------------------------------------------
+  - title: Update() Function
+    source: |
+      private void Update()
+      {
+        {function_body}
+      }
+
+    target: |
+      func _process(delta: float) -> void:
+      {
+        {translated_function_body}
+      }
+# ---------------------------------------------------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,6 @@ tqdm
 # warning from openai
 urllib3==1.26.6
 
-
+# sentence-transformers and chromadb are used for KnownTranslationsDb implemenation
 sentence-transformers>=2.2
 chromadb>=0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ tqdm
 urllib3==1.26.6
 
 
+sentence-transformers>=2.2
+chromadb>=0.4

--- a/tests/test_known_translations_db.py
+++ b/tests/test_known_translations_db.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import unittest
+
+from unifree.known_translations_db import KnownTranslationsDb, KnownTranslation
+from unifree.utils import to_default_dict
+
+
+# Copyright (c) Unifree
+# This code is licensed under MIT license (see LICENSE.txt for details)
+
+
+class KnownTranslationsDbProxy(KnownTranslationsDb):
+    def _upsert_translations_from_yaml(self, language: str) -> None:
+        # Do not lookup yaml file, instead upsert manually
+        self._upsert_translations([
+            KnownTranslation(
+                source="Hello, world!",
+                target="Sentence One",
+            ),
+            KnownTranslation(
+                source="Sator arepo tenet opera rotas",
+                target="Sentence Two",
+            ),
+        ])
+
+
+class TestKnownTranslationsDb(unittest.TestCase):
+    _db: KnownTranslationsDbProxy
+
+    def test_fetch_nearest(self):
+        self._db.initialize()
+
+        result = self._db.fetch_nearest_known_translations("Sator arepo", count=1)
+        self.assertEqual(1, len(result))
+        self.assertEqual("Sator arepo tenet opera rotas", result[0].source)
+        self.assertEqual("Sentence Two", result[0].target)
+
+    def test_fetch_nearest_as_query_history(self):
+        self._db.initialize()
+
+        result = self._db.fetch_nearest_as_query_history("Hello")
+        self.assertEqual(4, len(result))
+
+        self.assertEqual("user", result[0].role)
+        self.assertEqual("'Hello, world!' is 'Sentence One'", result[0].content)
+
+        self.assertEqual("assistant", result[1].role)
+        self.assertEqual("!OK!", result[1].content)
+
+        self.assertEqual("user", result[2].role)
+        self.assertEqual("'Sator arepo tenet opera rotas' is 'Sentence Two'", result[2].content)
+
+        self.assertEqual("assistant", result[3].role)
+        self.assertEqual("!OK!", result[3].content)
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._db = KnownTranslationsDbProxy(to_default_dict({
+            "known_translations": {
+                "language": "trivial",
+                "embedding_function": "all-MiniLM-L6-v2",
+                "result_count": 2,
+                "assistant_response": "!OK!",
+                "user_request": "'${SOURCE}' is '${TARGET}'",
+            }
+        }))

--- a/unifree/__init__.py
+++ b/unifree/__init__.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-
+import pathlib
 # Copyright (c) Unifree
 # This code is licensed under MIT license (see LICENSE.txt for details)
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Optional, Dict, List, Callable, TypeVar
+from typing import Optional, Dict, List
 
 # =====================
 # Overall Configuration
@@ -16,6 +16,9 @@ log_level: Optional[str] = 'info'
 
 supress_warnings: bool = False
 """If true 'warn'-level messages would be logged into stderr"""
+
+project_root: str = str(pathlib.Path(__file__).parent.parent.resolve())
+"""This is the _root_ folder of the project. All resource files (config, known translations, etc.) will be relative to this folder"""
 
 
 class MigrationStrategy(ABC):

--- a/unifree/known_translations_db.py
+++ b/unifree/known_translations_db.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Unifree
+# This code is licensed under MIT license (see LICENSE.txt for details)
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional, List, Iterable
+
+import chromadb
+import yaml
+from attr import dataclass
+from sentence_transformers import SentenceTransformer
+
+import unifree
+from unifree import log
+
+
+@dataclass
+class KnownTranslation:
+    source: str
+    target: str
+
+    @classmethod
+    def from_dict(cls, input_dict: Dict) -> KnownTranslation:
+        return KnownTranslation(
+            source=input_dict['source'],
+            target=input_dict['target'],
+        )
+
+
+class KnownTranslationsDb:
+    _class_instance: Optional[KnownTranslationsDb] = None
+
+    _config: Dict
+
+    _chroma_client: Optional[chromadb.Client]
+    _collection: Optional[chromadb.Collection]
+    _sentence_transformer: Optional[SentenceTransformer]
+    _default_n_results: Optional[int]
+
+    def __init__(self, config: Dict) -> None:
+        self._config = config
+        self._collection = None
+        self._sentence_transformer = None
+        self._default_n_results = None
+
+    def fetch_nearest_as_query_history(self, query: str, count: Optional[int] = None) -> List[unifree.QueryHistoryItem]:
+        result = []
+        known_translations = self.fetch_nearest_known_translations(query, count)
+        if len(known_translations) > 0:
+            translations_config = self._config["known_translations"]
+            assistant_response = translations_config["assistant_response"]
+            user_request_template = translations_config["user_request"]
+
+            for known_translation in known_translations:
+                user_request = user_request_template \
+                    .replace("${SOURCE}", known_translation.source) \
+                    .replace("${TARGET}", known_translation.target)
+
+                result.append(unifree.QueryHistoryItem(
+                    role="user",
+                    content=user_request
+                ))
+                result.append(unifree.QueryHistoryItem(
+                    role="assistant",
+                    content=assistant_response
+                ))
+
+        return result
+
+    def fetch_nearest_known_translations(self, query: str, count: Optional[int] = None) -> List[KnownTranslation]:
+        if self._collection:
+            if not count:
+                count = self._default_n_results
+
+            results = self._collection.query(
+                query_embeddings=[self._sentence_transformer.encode(query).tolist()],
+                n_results=count,
+            )
+
+            documents = results['documents']
+            metadatas = results['metadatas']
+
+            if len(metadatas) > 0 and len(documents) > 0:
+                return [KnownTranslation(
+                    source=document,
+                    target=metadata['target'],
+
+                ) for document, metadata in zip(documents[0], metadatas[0])]
+
+        log.debug("Known translations DB was not initialized, not returning anything")
+        return []
+
+    def initialize(self) -> None:
+        if self._collection is not None:
+            return  # Already initialized
+
+        if self._config["known_translations"]:
+            translations_config = self._config["known_translations"]
+            target_engine = translations_config["target_engine"]
+
+            self._default_n_results = translations_config["result_count"]
+
+            log.debug("Loading sentence transformer...")
+            os.environ["TOKENIZERS_PARALLELISM"] = "false"
+            self._sentence_transformer = self._create_sentence_transformer(translations_config)
+
+            log.debug("Creating and filling up sentence DB...")
+            self._chroma_client = chromadb.Client()
+            self._collection = self._chroma_client.create_collection(
+                name=f"{target_engine}-known-translations",
+                embedding_function=self._sentence_transformer
+            )
+            self._upsert_translations_from_yaml(target_engine)
+
+    def _create_sentence_transformer(self, translations_config: Dict) -> SentenceTransformer:
+        embedding_function_name = translations_config["embedding_function"]
+
+        return SentenceTransformer(embedding_function_name)
+
+    def _upsert_translations_from_yaml(self, target_engine: str) -> None:
+        known_translations_file_path = os.path.join(unifree.project_root, "known_translations", f"{target_engine}.yaml")
+        if not os.path.exists(known_translations_file_path) or not os.path.isfile(known_translations_file_path):
+            log.warn(f"No requested known translations found at '{known_translations_file_path}'")
+            return
+
+        with open(known_translations_file_path, 'r') as known_translations_file:
+            known_translations = yaml.safe_load(known_translations_file)
+
+        if "translations" in known_translations:
+            translations = map(KnownTranslation.from_dict, known_translations['translations'])
+            self._upsert_translations(translations)
+
+        else:
+            log.warn(f"'{known_translations_file_path}' is malformed: no root node called 'translations' found")
+
+    def _upsert_translations(self, translations: Iterable[KnownTranslation]) -> None:
+        documents = []
+        metadatas = []
+        ids = []
+
+        for translation in translations:
+            documents.append(translation.source)
+            metadatas.append({
+                'target': translation.target,
+            })
+            ids.append(str(len(ids) + 1))
+
+        embeddings = self._sentence_transformer.encode(documents).tolist()
+
+        self._collection.upsert(
+            documents=documents,
+            embeddings=embeddings,
+            metadatas=metadatas,
+            ids=ids,
+        )
+        log.debug(f"Inserted {len(ids):,} known translations")
+
+    @classmethod
+    def instance(cls) -> KnownTranslationsDb:
+        if not cls.is_instance_initialized():
+            raise RuntimeError(f"Known translations DB is not initialized")
+
+        return cls._class_instance
+
+    @classmethod
+    def is_instance_initialized(cls) -> bool:
+        return cls._class_instance is not None
+
+    @classmethod
+    def initialize_instance(cls, config: Dict) -> None:
+        cls._class_instance = KnownTranslationsDb(config)
+        cls._class_instance.initialize()

--- a/unifree/llms/chatgpt_llm.py
+++ b/unifree/llms/chatgpt_llm.py
@@ -76,7 +76,11 @@ class ChatGptLLM(LLM):
 
             response = completion.choices[0].message.content
 
-            log.debug(f"\n==== GPT REQUEST ====\n{user}\n\n==== GPT RESPONSE ====\n{response}\n")
+            if log.is_debug():
+                messages_str = [f"> {m['role']}: {m['content']}" for m in messages]
+                messages_str = "\n\n".join(messages_str)
+
+                log.debug(f"\n==== GPT REQUEST ====\n{messages_str}\n\n==== GPT RESPONSE ====\n{response}\n")
 
             return response
         except Exception as e:

--- a/unifree/project_migration_strategies.py
+++ b/unifree/project_migration_strategies.py
@@ -132,6 +132,9 @@ class CreateMigrations(ConcurrentMigrationStrategy):
         from unifree.source_code_parsers import CSharpCodeParser
         CSharpCodeParser.initialize()
 
+        from unifree.known_translations_db import KnownTranslationsDb
+        KnownTranslationsDb.initialize_instance(self.config)
+
     def _check_if_source_is_unity_project(self):
         files = os.listdir(self._source_path)
         for required_file in ['Assets', 'ProjectSettings']:

--- a/unifree/source_code_parsers.py
+++ b/unifree/source_code_parsers.py
@@ -8,6 +8,7 @@ from typing import Dict
 
 import tree_sitter
 
+import unifree
 from unifree import log
 
 
@@ -27,11 +28,9 @@ class CSharpCodeParser:
         c_sharp_library_path = cls._c_sharp_library_path()
         if not os.path.exists(c_sharp_library_path):
             c_sharp_library_folder_path = os.path.dirname(c_sharp_library_path)
-            folder_containing_vendor = os.path.dirname(os.path.dirname(os.path.dirname(c_sharp_library_folder_path)))
-
             log.debug(f"C# library not found at '{c_sharp_library_path}', building...")
 
-            tree_sitter_csharp_folder_path = os.path.join(folder_containing_vendor, 'vendor', 'tree-sitter-c-sharp')
+            tree_sitter_csharp_folder_path = os.path.join(unifree.project_root, 'vendor', 'tree-sitter-c-sharp')
             if not os.path.exists(tree_sitter_csharp_folder_path):
                 log.error(f"CSharp implementation of the tree sitter is not found at {tree_sitter_csharp_folder_path}")
                 raise RuntimeError(f"CSharp tree sitter not found in {tree_sitter_csharp_folder_path}")
@@ -66,25 +65,8 @@ class CSharpCodeParser:
 
     @classmethod
     def _c_sharp_library_path(cls) -> str:
-        # Try to find 'vendor' folder
-        current_folder_path = os.path.abspath(os.curdir)
-        folder_containing_vendor = cls._find_vendor_folder(current_folder_path, 4)
-
-        c_sharp_library_folder_path = os.path.join(folder_containing_vendor, 'vendor', 'build', 'libraries')
+        c_sharp_library_folder_path = os.path.join(unifree.project_root, 'vendor', 'build', 'libraries')
         return os.path.join(c_sharp_library_folder_path, 'c-sharp.so')
-
-    @classmethod
-    def _find_vendor_folder(cls, current_folder_path: str, remaining_depth: int) -> str:
-        if remaining_depth <= 0:
-            log.error("Unable to locate 'vendor' folder that is necessary for reading the code. Please make sure your project is setup correctly")
-            raise RuntimeError(f"Can't locate 'vendor' folder")
-
-        if os.path.isdir(current_folder_path):
-            for file_name in os.listdir(current_folder_path):
-                if os.path.isdir(os.path.join(current_folder_path, file_name)) and file_name == 'vendor':
-                    return current_folder_path
-
-        return cls._find_vendor_folder(os.path.dirname(current_folder_path), remaining_depth - 1)
 
     def _replace_macros_with_comments(self, source_str):
         result = ''

--- a/unifree/utils.py
+++ b/unifree/utils.py
@@ -16,16 +16,13 @@ from unifree import LLM
 
 def load_config(config_name: str) -> Dict[str, Any]:
     from unifree import log
+    import unifree
 
-    config_file_name = f"configs/{config_name}.yaml"
-    for potential_config_path in [config_file_name, os.path.join("..", config_file_name)]:
-        if os.path.exists(potential_config_path) and os.path.isfile(config_file_name):
-            config_file_name = potential_config_path
-            break
-
+    config_folder_path = os.path.join(unifree.project_root, "configs")
+    config_file_name = os.path.join(config_folder_path, f"{config_name}.yaml")
     if not os.path.exists(config_file_name) or not os.path.isfile(config_file_name):
         supported_destinations = []
-        for config_file_name in os.listdir("configs/"):
+        for config_file_name in os.listdir(config_folder_path):
             if config_file_name.endswith(".yaml"):
                 supported_destinations.append(config_file_name.replace(".yaml", ""))
 


### PR DESCRIPTION
Using `known_translations/{target_engine}.yaml` with a collection of known correct translations.

Use chromadb as a vector DB for embeddings of known translations. Lookup closest translations and add them into the translation context on each query.

Example configuration:
```
known_translations:
  target_engine: godot
  embedding_function: krlvi/sentence-t5-base-nlpl-code_search_net
  result_count: 5
  user_request: |
    Remember this correct translation from Unity: 
    ```
    ${SOURCE}
    ```
    is translated as:
    ```
    ${TARGET}
    ```
  assistant_response: Certainly! I will remember this translation.
```

Where example content of the known translations file is:
```
translations:
  - title: Ternary Operators
    source: |
      variable = {condition} ? (true_statement) : (false_statement);
    target: |
      variable = {translated_true_statement} if {translated_condition} else "{translated_false_statement}
  # ---------------------------------------------------------------------------------------------------------------------
  - title: Start() Function
    source: |
      private void Start()
      {
        {function_body}
      }

    target: |
      func _ready() -> void:
      {
        {translated_function_body}
      }
  # ---------------------------------------------------------------------------------------------------------------------
```