### PR TITLE
Corrected typo in ternary translation

### DIFF
--- a/known_translations/godot.yaml
+++ b/known_translations/godot.yaml
@@ -3,7 +3,7 @@ translations:
     source: |
       variable = {condition} ? (true_statement) : (false_statement);
     target: |
-      variable = {translated_true_statement} if {translated_condition} else "{translated_false_statement}
+      variable = {translated_true_statement} if {translated_condition} else {translated_false_statement}
   # ---------------------------------------------------------------------------------------------------------------------
   - title: Start() Function
     source: |


### PR DESCRIPTION
There was an extra " in the ternary file, causing the rest of the yaml to be interpreted as an un-terminated string.