### PR TITLE
config/bug/show_test_logs_in_summary_and_details

### DIFF
--- a/.github/workflows/python-unittest.yml
+++ b/.github/workflows/python-unittest.yml
@@ -28,5 +28,6 @@ jobs:
       - name: Test with unittest
         run: |
           # Store output in GITHUB_STEP_SUMMARY for easy reading on Github.com
-          python -m unittest -v $GITHUB_WORKSPACE/tests/*.py &> $GITHUB_STEP_SUMMARY
-          cat $GITHUB_STEP_SUMMARY
+          python -m unittest -v $GITHUB_WORKSPACE/tests/*.py 2>&1 | tee $GITHUB_STEP_SUMMARY
+          # If python test fails, we want the step to fail.
+          exit ${PIPESTATUS[0]}


### PR DESCRIPTION
Fixes an issue where the tests failures where only visible on the summary screen and not the specific step screen.
|Old jobs steps screen|New jobs steps screen|
|-|-|
|![Screenshot 2023-09-22 at 11 08 20 AM](https://github.com/ProjectUnifree/unifree/assets/13296512/b2f0fed8-0f6e-467b-b9b3-4db47bd62edc)|![Screenshot 2023-09-22 at 11 09 39 AM](https://github.com/ProjectUnifree/unifree/assets/13296512/e7de4ade-b9dd-4ec2-950c-ec9f7c4985db)|

