### PR TITLE
Fixed mistakes with md & grammar & Batch

### DIFF
--- a/RunningLocalModels.md
+++ b/RunningLocalModels.md
@@ -1,6 +1,6 @@
 # Running Local Models
 
-## Install 'unifree' and activate the Environment
+## Install 'unifree' and activate the Python Virtual Environment
 
 ### Linux/MacOS
 

--- a/RunningLocalModels.md
+++ b/RunningLocalModels.md
@@ -1,6 +1,6 @@
 # Running Local Models
 
-## Install 'unifree' and Active the Environment
+## Install 'unifree' and activate the Environment
 
 ### Linux/MacOS
 
@@ -16,7 +16,7 @@ source venv/bin/activate
 ```
 git clone https://github.com/ProjectUnifree/unifree
 cd unifree
-launch.bat
+.\launch.bat
 .\venv\Scripts\activate.bat
 ```
 
@@ -28,4 +28,4 @@ the inference speed.
 
 ## Use unifree as usual
 
-(See main README.md for usage)[https://github.com/ProjectUnifree/unifree#installation-and-usage]. 
+[See main README.md for usage.](https://github.com/ProjectUnifree/unifree#installation-and-usage) 


### PR DESCRIPTION
- Small grammar mistake in the beginning header
- Batch uses `.\` to run scripts
- The bottom markdown link was broken